### PR TITLE
Redirect UnixTools to GMT docs

### DIFF
--- a/content/blog/2016-10-29-unix-tools-for-windows/index.md
+++ b/content/blog/2016-10-29-unix-tools-for-windows/index.md
@@ -10,7 +10,7 @@ categories:
 tags:
     - Linux
     - Windows    
-redirect: https://docs.gmt-china.org/latest/install/windows/#id1
+redirect: https://docs.gmt-china.org/latest/install/windows/#unixtools
 
 ---
 

--- a/content/blog/2016-10-29-unix-tools-for-windows/index.md
+++ b/content/blog/2016-10-29-unix-tools-for-windows/index.md
@@ -9,7 +9,9 @@ categories:
     - GMT工具
 tags:
     - Linux
-    - Windows
+    - Windows    
+redirect: https://docs.gmt-china.org/latest/install/windows/#id1
+
 ---
 
 <i class="fas fa-download"></i> [UnixTools.zip](/data/UnixTools.zip)


### PR DESCRIPTION
I am considering using level-3 title for each tool in GMT_docs.
**Preview**: https://gmt-china.github.io/sitepreview/gmt-china/gmt-china.org/unixtools/blog/unix-tools-for-windows/

- Related to https://github.com/gmt-china/GMT_docs/issues/501.
- Merged this PR after https://github.com/gmt-china/GMT_docs/pull/512.